### PR TITLE
Enable automation with user argument passed to shell script 

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,3 +1,7 @@
+#0.7.2
+Updated on 11/25/2016 by Defilan. 
+-Modified adhd-install.sh to accept argument for specific user. (Allows for automation)
+-Modified adhd-install.sh to create ssh key (public/private) automatically without the need for a passcode (Allows for automation)
 #0.7.1
 Added Cowrie
 Updated documentation style

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Updated on 11/25/2016 by Defilan. 
+-Modified adhd-install.sh to accept argument for specific user. (Allows for automation)
+-Modified adhd-install.sh to create ssh key (public/private) automatically without the need for a passcode (Allows for automation)
+
 Currently, only Ubuntu versions 16.04 LTS and 15.10 32-bit are explicitly supported (installation may or may not work on a different version number).  We recommend you do a clean install before running the script here.
 
 As always, read the script before blindly executing code from the internet but here is the one-liner to bootstrap your ADHD installation.

--- a/adhd-install.sh
+++ b/adhd-install.sh
@@ -10,7 +10,6 @@ if [ -z "$ubuntu_version" ]; then ubuntu_version="15.10"; fi
 
 if [[ $1 != "" ]]; then
 account=$1
-echo $account
 else
 echo "This script will need to associate a user account with all the tools."
 echo "Enter the name of a user account you want associated with the install."

--- a/adhd-install.sh
+++ b/adhd-install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 if [ `whoami` != 'root' ]; then
 echo "need to run as root, or with sudo"; exit
 fi
@@ -7,12 +8,17 @@ fi
 ubuntu_version=`lsb_release -a 2>/dev/null | grep release -i | cut -f2`
 if [ -z "$ubuntu_version" ]; then ubuntu_version="15.10"; fi
 
+if [[ $1 != "" ]]; then
+account=$1
+echo $account
+else
 echo "This script will need to associate a user account with all the tools."
 echo "Enter the name of a user account you want associated with the install."
 echo "If you enter a new account name... It will be created." 
 echo -n "Enter account name [adhd]: "
 read account
 echo
+fi
 
 if [ ${#account} == 0 ]; then
 account="adhd"
@@ -38,7 +44,7 @@ echo "# Need to generate keys for cowrie #"
 echo "####################################"
 echo
 echo
-ssh-keygen -t dsa -b 1024 -f ssh_host_dsa_key
+ssh-keygen -t dsa -b 1024 -f ssh_host_dsa_key -N ''
 
 apt-get update
 


### PR DESCRIPTION
This update allows for adhd-install.sh to be called and executed via automation tools (Chef, Puppet, etc) by passing a user argument adhd-install.sh. 

Example:

sudo ./adhd-install.sh testuser